### PR TITLE
Fix next<T> for narrow integral types on libc++ (Apple clang / macOS)

### DIFF
--- a/single_include/tgen.h
+++ b/single_include/tgen.h
@@ -649,13 +649,28 @@ template <typename... Args> struct print_cols {
  * Global random operations.
  */
 
+namespace detail {
+// libstdc++ accepts std::uniform_int_distribution with narrow integral types
+// (char/signed char/unsigned char/short/bool), but libc++ rejects them with a
+// hard static_assert ("IntType must be a supported integer type"). Promote such
+// types to a width the standard guarantees, preserving signedness, so the same
+// `next<T>` works across both standard libraries (e.g. Apple clang / libc++).
+template <typename T>
+using uniform_int_t = std::conditional_t<
+	(sizeof(T) >= sizeof(short)), T,
+	std::conditional_t<std::is_signed_v<T>, int, unsigned int>>;
+} // namespace detail
+
 // Returns a uniformly random number in [0, right)
 // O(1).
 template <typename T> T next(T right) {
 	detail::ensure_registered();
 	if constexpr (std::is_integral_v<T>) {
 		tgen_ensure(right >= 1, "value for `next` must be valid");
-		return std::uniform_int_distribution<T>(0, right - 1)(detail::rng);
+		return static_cast<T>(
+			std::uniform_int_distribution<detail::uniform_int_t<T>>(
+				0,
+				static_cast<detail::uniform_int_t<T>>(right) - 1)(detail::rng));
 	} else if constexpr (std::is_floating_point_v<T>) {
 		tgen_ensure(right >= 0, "value for `next` must be valid");
 		return std::uniform_real_distribution<T>(0, right)(detail::rng);
@@ -670,7 +685,10 @@ template <typename T> T next(T left, T right) {
 	detail::ensure_registered();
 	tgen_ensure(left <= right, "range for `next` must be valid");
 	if constexpr (std::is_integral_v<T>)
-		return std::uniform_int_distribution<T>(left, right)(detail::rng);
+		return static_cast<T>(
+			std::uniform_int_distribution<detail::uniform_int_t<T>>(
+				static_cast<detail::uniform_int_t<T>>(left),
+				static_cast<detail::uniform_int_t<T>>(right))(detail::rng));
 	else if constexpr (std::is_floating_point_v<T>)
 		return std::uniform_real_distribution<T>(left, right)(detail::rng);
 	else


### PR DESCRIPTION
## Problem

`tgen.h` fails to **compile at all** under libc++ (e.g. Apple clang on macOS), even for a trivial program that only does `#include "tgen.h"` and `register_gen`:

```
__random/uniform_int_distribution.h: static assertion failed due to requirement
'__libcpp_random_is_valid_inttype<char>::value': IntType must be a supported integer type
note: in instantiation of member function 'tgen::list<char>::gen' requested here
```

`std::uniform_int_distribution` is only *required* by the C++ standard to support `short/int/long/long long` and their unsigned variants. libstdc++ additionally accepts `char`/`signed char`/`unsigned char`/`bool`, but **libc++ enforces the standard** with a hard `static_assert`.

The string/regex generator instantiates `list<char>` (and therefore `next<char>`) unconditionally, so the failure happens just from including the header — no narrow-type usage by the caller is required.

## Fix

Inside `next<T>`, promote narrow integral types to a standard-guaranteed width (preserving signedness) via a small `detail::uniform_int_t<T>` alias, run the distribution on that type, then `static_cast` back to `T`. Wider integral types and floating-point paths are untouched.

This is the conventional workaround for this well-known libc++ restriction and keeps behavior identical on libstdc++.

## Verification

A test exercising `next<char>`, `next<short>`, `next<unsigned char>`, `next<int>`, `next<long long>` and the `list<char>` string path:

- ✅ LLVM clang 19 + libc++, C++17 and C++20
- ✅ Apple clang (Xcode) + libc++, C++20
- ✅ gcc-15 + libstdc++, C++20 — no regression

`make lint-check` (clang-format) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)