### PR TITLE
Add LLM-friendly documentation tree

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
           sudo mv doxygen-${DOXYGEN_VERSION}/bin/doxygen /usr/local/bin/
 
       - name: Build documentation
-        run: make doc
+        run: make doc llms
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ docs/build/
 # VsCode
 .vscode
 Testing
+
+# Python (docs/llms_gen.py tooling)
+__pycache__/

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1111,7 +1111,8 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = */llms_gen.py \
+                         */test_llms_gen.py
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/docs/llms_gen.py
+++ b/docs/llms_gen.py
@@ -47,7 +47,23 @@ EXPECTED_MODULES = [
     "misc",
 ]
 
+# Titled markdown headings nest as sect1..sect4; only the innermost carries a
+# <title>. Doxygen has no sect5/sect6, so a titled section deeper than sect4
+# would fall through render_node's catch-all (children rendered, heading lost)
+# -- a documented limitation; the current XML has no such case.
 _SECT_TAGS = {"sect1": 2, "sect2": 3, "sect3": 4, "sect4": 5}
+
+# Visibility-scoped output blocks whose contents target a non-markdown format
+# (raw HTML/JS, LaTeX, etc.). Their inner content is dropped entirely so e.g.
+# an interactive <htmlonly> widget never leaks into the generated markdown.
+_SKIP_TAGS = {
+    "htmlonly",
+    "manonly",
+    "latexonly",
+    "rtfonly",
+    "xmlonly",
+    "docbookonly",
+}
 
 _PARAMLIST_LABELS = {
     "param": "Parameters",
@@ -160,14 +176,24 @@ def _render_parameterlist(node):
 
 def _render_simplesect(node):
     label = _SIMPLESECT_LABELS.get(node.get("kind"), "Note")
+    # Preserve block content (code fences, lists) verbatim: only trim outer
+    # whitespace rather than squashing all newlines, so a fenced block or a
+    # bullet list inside a @note/@warning keeps its own lines.
     body = render_children(node).strip()
-    body = re.sub(r"\n+", " ", body).strip()
     return "\n**%s:** %s\n" % (label, body)
 
 
 def render_node(node):
     """Render a single XML element to markdown. Never silently drops content."""
     tag = node.tag
+    if tag in _SKIP_TAGS:
+        # Drop format-specific content (raw HTML/JS, LaTeX, ...) entirely; the
+        # element's own tail is appended by the caller's render loop.
+        return ""
+    if tag == "ndash":
+        return "--"
+    if tag == "mdash":
+        return "---"
     if tag == "para":
         return render_children(node).strip() + "\n\n"
     if tag == "computeroutput":
@@ -270,11 +296,29 @@ def render_compound_members(compounddef):
     return "\n\n".join(parts)
 
 
+def _die(path, reason):
+    """Exit non-zero with a clear ``tgen llms_gen: <path>: <reason>`` message."""
+    sys.stderr.write("tgen llms_gen: %s: %s\n" % (path, reason))
+    sys.exit(1)
+
+
+def _parse_xml(path):
+    """Parse an XML file, exiting cleanly on missing/unreadable/malformed input."""
+    try:
+        return ET.parse(path).getroot()
+    except FileNotFoundError:
+        _die(path, "file not found")
+    except OSError as exc:
+        _die(path, str(exc))
+    except ET.ParseError as exc:
+        _die(path, "malformed XML (%s)" % exc)
+
+
 def _load_compounddef(xml_dir, refid):
     path = os.path.join(xml_dir, refid + ".xml")
     if not os.path.isfile(path):
         return None
-    return ET.parse(path).getroot().find("compounddef")
+    return _parse_xml(path).find("compounddef")
 
 
 def _compounddef_brief(compounddef):
@@ -337,7 +381,7 @@ def render_group(xml_dir, compounddef):
 
 def discover_groups(xml_dir):
     """Return ``[(name, refid), ...]`` for group compounds, in index order."""
-    root = ET.parse(os.path.join(xml_dir, "index.xml")).getroot()
+    root = _parse_xml(os.path.join(xml_dir, "index.xml"))
     groups = []
     for compound in root.findall("compound"):
         if compound.get("kind") == "group":

--- a/docs/llms_gen.py
+++ b/docs/llms_gen.py
@@ -24,6 +24,24 @@ import re
 
 _SECT_TAGS = {"sect1": 2, "sect2": 3, "sect3": 4, "sect4": 5}
 
+_PARAMLIST_LABELS = {
+    "param": "Parameters",
+    "templateparam": "Template parameters",
+    "retval": "Return values",
+    "exception": "Exceptions",
+}
+
+_SIMPLESECT_LABELS = {
+    "return": "Returns",
+    "note": "Note",
+    "warning": "Warning",
+    "see": "See also",
+    "since": "Since",
+    "pre": "Precondition",
+    "post": "Postcondition",
+    "attention": "Attention",
+}
+
 
 def _text(s):
     return s if s else ""
@@ -93,6 +111,33 @@ def _render_section(node):
     return render_children(node)
 
 
+def _render_parameterlist(node):
+    label = _PARAMLIST_LABELS.get(node.get("kind"), "Parameters")
+    lines = ["\n**%s:**\n\n" % label]
+    for item in node.findall("parameteritem"):
+        names = []
+        for nl in item.findall("parameternamelist"):
+            for pn in nl.findall("parametername"):
+                names.append("".join(pn.itertext()).strip())
+        desc_el = item.find("parameterdescription")
+        desc = render_children(desc_el).strip() if desc_el is not None else ""
+        desc = re.sub(r"\n+", " ", desc).strip()
+        name_str = ", ".join("`%s`" % n for n in names if n)
+        if desc:
+            lines.append("- %s — %s\n" % (name_str, desc))
+        else:
+            lines.append("- %s\n" % name_str)
+    lines.append("\n")
+    return "".join(lines)
+
+
+def _render_simplesect(node):
+    label = _SIMPLESECT_LABELS.get(node.get("kind"), "Note")
+    body = render_children(node).strip()
+    body = re.sub(r"\n+", " ", body).strip()
+    return "\n**%s:** %s\n" % (label, body)
+
+
 def render_node(node):
     """Render a single XML element to markdown. Never silently drops content."""
     tag = node.tag
@@ -116,6 +161,10 @@ def render_node(node):
         return _render_list(node, ordered=False)
     if tag == "orderedlist":
         return _render_list(node, ordered=True)
+    if tag == "parameterlist":
+        return _render_parameterlist(node)
+    if tag == "simplesect":
+        return _render_simplesect(node)
     if tag == "linebreak":
         return "\n"
     if tag == "sp":

--- a/docs/llms_gen.py
+++ b/docs/llms_gen.py
@@ -18,11 +18,34 @@ Notes on this project's actual XML (Doxygen 1.17.0):
   * The ``@tt{}`` / ``@pname{}`` family of aliases expand to spans that are
     stripped in XML output, leaving only their (often auto-linked) inner text,
     so there is no leftover ``@...{`` markup to handle for them.
+  * Typed-generator groups (list, str, tree, ...) have no direct members; their
+    API lives in ``<innerclass>`` structs which must be loaded and rendered.
 """
 
+import argparse
 import os
 import re
+import sys
 import xml.etree.ElementTree as ET
+
+# Matches any leftover unconverted Doxygen alias markup, e.g. ``@tt{``.
+MARKUP_RE = re.compile(r"@[a-zA-Z]+\{")
+
+# Modules that MUST be present in the generated output (subset check). Extra
+# groups (e.g. ``generator_value_op``) are allowed and must not cause failure.
+EXPECTED_MODULES = [
+    "base",
+    "opts",
+    "list",
+    "pair",
+    "permutation",
+    "str",
+    "tree",
+    "graph",
+    "math",
+    "hack",
+    "misc",
+]
 
 _SECT_TAGS = {"sect1": 2, "sect2": 3, "sect3": 4, "sect4": 5}
 
@@ -76,6 +99,8 @@ def _render_codeline_text(node):
     for child in node:
         if child.tag == "sp":
             parts.append(" ")
+        elif child.tag == "highlight":
+            parts.append(_render_codeline_text(child))
         else:
             parts.append(_render_codeline_text(child))
         parts.append(_text(child.tail))
@@ -303,3 +328,121 @@ def render_group(xml_dir, compounddef):
             parts.append(inner_members + "\n\n")
 
     return _collapse("".join(parts)) + "\n"
+
+
+# --------------------------------------------------------------------------
+# Index discovery + generation + validation
+# --------------------------------------------------------------------------
+
+
+def discover_groups(xml_dir):
+    """Return ``[(name, refid), ...]`` for group compounds, in index order."""
+    root = ET.parse(os.path.join(xml_dir, "index.xml")).getroot()
+    groups = []
+    for compound in root.findall("compound"):
+        if compound.get("kind") == "group":
+            refid = compound.get("refid")
+            name = compound.findtext("name", "").strip()
+            groups.append((name, refid))
+    return groups
+
+
+def generate(xml_dir, out_dir, base_url):
+    llms_dir = os.path.join(out_dir, "llms")
+    os.makedirs(llms_dir, exist_ok=True)
+
+    entries = []
+    for name, refid in discover_groups(xml_dir):
+        compounddef = _load_compounddef(xml_dir, refid)
+        if compounddef is None:
+            continue
+        md = render_group(xml_dir, compounddef)
+        leftover = MARKUP_RE.search(md)
+        if leftover:
+            sys.stderr.write(
+                "tgen llms_gen: unconverted Doxygen markup %r in module %r\n"
+                % (leftover.group(0), name)
+            )
+            sys.exit(1)
+        with open(os.path.join(llms_dir, name + ".md"), "w") as f:
+            f.write(md)
+        entries.append((name, group_brief(compounddef)))
+
+    _write_index(out_dir, base_url, entries)
+    _validate(out_dir, [n for n, _ in entries])
+    return entries
+
+
+def _write_index(out_dir, base_url, entries):
+    base = base_url.rstrip("/")
+    lines = [
+        "# tgen\n",
+        "\n",
+        "> tgen is a header-only C++17 library for writing random testcase "
+        "generators, emphasizing declarative constraints, provably uniform "
+        "sampling, and adversarial (\"hack\") generation. The core pipeline is "
+        "generator -> `.gen()` -> value operations: a generator describes the "
+        "set of valid objects under constraints, `.gen()` samples one uniformly "
+        "at random, and value operations mutate the sampled value. The whole "
+        "library is a single header, `single_include/tgen.h`.\n",
+        "\n",
+        "## Modules\n",
+        "\n",
+    ]
+    for name, brief in entries:
+        url = "%s/llms/%s.md" % (base, name)
+        if brief:
+            lines.append("- [%s](%s) — %s\n" % (name, url, brief))
+        else:
+            lines.append("- [%s](%s)\n" % (name, url))
+    lines.append("\n")
+    lines.append("## Source\n")
+    lines.append("\n")
+    lines.append(
+        "- [single_include/tgen.h]"
+        "(https://github.com/rsalesc/tgen/blob/main/single_include/tgen.h) — "
+        "the entire library (one header).\n"
+    )
+    with open(os.path.join(out_dir, "llms.txt"), "w") as f:
+        f.write("".join(lines))
+
+
+def _validate(out_dir, generated_names):
+    ok = True
+    missing = [m for m in EXPECTED_MODULES if m not in generated_names]
+    if missing:
+        sys.stderr.write(
+            "tgen llms_gen: missing expected modules: %s\n" % ", ".join(missing)
+        )
+        ok = False
+    if not os.path.isfile(os.path.join(out_dir, "llms.txt")):
+        sys.stderr.write("tgen llms_gen: llms.txt was not written\n")
+        ok = False
+    if not ok:
+        sys.exit(1)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Convert Doxygen XML into LLM-friendly markdown docs."
+    )
+    parser.add_argument("--xml", required=True, help="Doxygen XML output dir")
+    parser.add_argument(
+        "--out", required=True, help="output dir for llms.txt + llms/"
+    )
+    parser.add_argument(
+        "--base-url",
+        default="https://rsalesc.github.io/tgen",
+        help="absolute base URL for generated links",
+    )
+    args = parser.parse_args(argv)
+
+    entries = generate(args.xml, args.out, args.base_url)
+    print(
+        "tgen llms_gen: wrote %d modules to %s"
+        % (len(entries), os.path.join(args.out, "llms"))
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/llms_gen.py
+++ b/docs/llms_gen.py
@@ -476,7 +476,7 @@ def main(argv=None):
     )
     parser.add_argument(
         "--base-url",
-        default="https://rsalesc.github.io/tgen",
+        default="https://brunomaletta.github.io/tgen",
         help="absolute base URL for generated links",
     )
     args = parser.parse_args(argv)

--- a/docs/llms_gen.py
+++ b/docs/llms_gen.py
@@ -20,7 +20,9 @@ Notes on this project's actual XML (Doxygen 1.17.0):
     so there is no leftover ``@...{`` markup to handle for them.
 """
 
+import os
 import re
+import xml.etree.ElementTree as ET
 
 _SECT_TAGS = {"sect1": 2, "sect2": 3, "sect3": 4, "sect4": 5}
 
@@ -195,3 +197,109 @@ def render_description(*nodes):
             continue
         parts.append(render_children(node))
     return _collapse("\n\n".join(parts))
+
+
+# --------------------------------------------------------------------------
+# Member / group / inner-struct rendering
+# --------------------------------------------------------------------------
+
+
+def _member_signature(m):
+    type_el = m.find("type")
+    type_str = "".join(type_el.itertext()).strip() if type_el is not None else ""
+    def_el = m.find("definition")
+    def_str = "".join(def_el.itertext()).strip() if def_el is not None else ""
+    args_el = m.find("argsstring")
+    args_str = "".join(args_el.itertext()).strip() if args_el is not None else ""
+
+    # ``definition`` usually already starts with the return type; prefer it.
+    if def_str:
+        sig = def_str + args_str
+    else:
+        name_el = m.find("name")
+        name = "".join(name_el.itertext()).strip() if name_el is not None else ""
+        sig = (type_str + " " + name).strip() + args_str
+    return re.sub(r"\s+", " ", sig).strip()
+
+
+def render_member(m):
+    name_el = m.find("name")
+    name = "".join(name_el.itertext()).strip() if name_el is not None else ""
+    sig = _member_signature(m)
+    desc = render_description(
+        m.find("briefdescription"), m.find("detaileddescription")
+    )
+    out = ["#### `%s`\n\n" % name, "```cpp\n%s\n```\n" % sig]
+    if desc:
+        out.append("\n" + desc + "\n")
+    return _collapse("".join(out)) + "\n"
+
+
+def render_compound_members(compounddef):
+    """Render every ``memberdef[kind="function"]`` across all sectiondefs."""
+    parts = []
+    for sectiondef in compounddef.findall("sectiondef"):
+        for m in sectiondef.findall("memberdef"):
+            if m.get("kind") == "function":
+                parts.append(render_member(m))
+    return "\n\n".join(parts)
+
+
+def _load_compounddef(xml_dir, refid):
+    path = os.path.join(xml_dir, refid + ".xml")
+    if not os.path.isfile(path):
+        return None
+    return ET.parse(path).getroot().find("compounddef")
+
+
+def _compounddef_brief(compounddef):
+    brief = compounddef.find("briefdescription")
+    if brief is None:
+        return ""
+    return _collapse(render_children(brief))
+
+
+def group_brief(compounddef):
+    """One-line brief for the group (newlines collapsed to spaces)."""
+    text = _compounddef_brief(compounddef)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def render_group(xml_dir, compounddef):
+    title_el = compounddef.find("title")
+    title = (
+        "".join(title_el.itertext()).strip()
+        if title_el is not None
+        else compounddef.findtext("compoundname", "")
+    )
+    parts = ["# %s\n\n" % title]
+
+    desc = render_description(
+        compounddef.find("briefdescription"),
+        compounddef.find("detaileddescription"),
+    )
+    if desc:
+        parts.append(desc + "\n\n")
+
+    own_members = render_compound_members(compounddef)
+    if own_members.strip():
+        parts.append("## API\n\n")
+        parts.append(own_members + "\n\n")
+
+    for innerclass in compounddef.findall("innerclass"):
+        refid = innerclass.get("refid")
+        inner = _load_compounddef(xml_dir, refid)
+        if inner is None:
+            continue
+        struct_name = inner.findtext("compoundname", "").strip()
+        parts.append("## `%s`\n\n" % struct_name)
+        inner_desc = render_description(
+            inner.find("briefdescription"), inner.find("detaileddescription")
+        )
+        if inner_desc:
+            parts.append(inner_desc + "\n\n")
+        inner_members = render_compound_members(inner)
+        if inner_members.strip():
+            parts.append(inner_members + "\n\n")
+
+    return _collapse("".join(parts)) + "\n"

--- a/docs/llms_gen.py
+++ b/docs/llms_gen.py
@@ -1,0 +1,148 @@
+"""Doxygen-XML -> LLM-friendly markdown converter for ``tgen``.
+
+Reads a Doxygen XML output directory (``GENERATE_XML=YES``) and emits an
+``llms.txt``-convention doc tree:
+
+    <out>/llms.txt          index linking to one markdown file per module
+    <out>/llms/<module>.md  one file per Doxygen @defgroup
+
+The goal is a self-contained markdown reference an LLM agent can fetch and
+navigate. See ``docs/plans/2026-05-20-llm-docs-design.md`` for the design.
+
+Stdlib only (``xml.etree`` + ``argparse``); no pip/node dependencies, matching
+the project's minimal-deps ethos.
+
+Notes on this project's actual XML (Doxygen 1.17.0):
+  * Markdown headings become nested ``sect1``..``sect4`` wrappers; only the
+    innermost section carries a ``<title>``.
+  * The ``@tt{}`` / ``@pname{}`` family of aliases expand to spans that are
+    stripped in XML output, leaving only their (often auto-linked) inner text,
+    so there is no leftover ``@...{`` markup to handle for them.
+"""
+
+import re
+
+_SECT_TAGS = {"sect1": 2, "sect2": 3, "sect3": 4, "sect4": 5}
+
+
+def _text(s):
+    return s if s else ""
+
+
+# --------------------------------------------------------------------------
+# Inline / block rich-text rendering
+# --------------------------------------------------------------------------
+
+
+def render_children(node):
+    """Render ``node.text`` + each child (via ``render_node``) + child tails."""
+    parts = [_text(node.text)]
+    for child in node:
+        parts.append(render_node(child))
+        parts.append(_text(child.tail))
+    return "".join(parts)
+
+
+def _render_programlisting(node):
+    lines = []
+    for codeline in node.findall("codeline"):
+        lines.append(_render_codeline_text(codeline))
+    code = "\n".join(lines).rstrip()
+    return "\n```cpp\n" + code + "\n```\n"
+
+
+def _render_codeline_text(node):
+    parts = [_text(node.text)]
+    for child in node:
+        if child.tag == "sp":
+            parts.append(" ")
+        else:
+            parts.append(_render_codeline_text(child))
+        parts.append(_text(child.tail))
+    return "".join(parts)
+
+
+def _render_list(node, ordered):
+    out = ["\n"]
+    for i, item in enumerate(node.findall("listitem"), start=1):
+        body = render_children(item).strip()
+        # collapse internal newlines so a bullet stays on one logical line
+        body = re.sub(r"\n+", " ", body).strip()
+        marker = "%d. " % i if ordered else "- "
+        out.append(marker + body + "\n")
+    out.append("\n")
+    return "".join(out)
+
+
+def _render_section(node):
+    title_el = node.find("title")
+    if title_el is not None:
+        level = _SECT_TAGS.get(node.tag, 2)
+        if level > 6:
+            level = 6
+        title = "".join(title_el.itertext()).strip()
+        body_parts = [_text(node.text)]
+        for child in node:
+            if child is title_el:
+                body_parts.append(_text(child.tail))
+                continue
+            body_parts.append(render_node(child))
+            body_parts.append(_text(child.tail))
+        body = "".join(body_parts).strip()
+        return "\n" + ("#" * level) + " " + title + "\n\n" + body + "\n"
+    return render_children(node)
+
+
+def render_node(node):
+    """Render a single XML element to markdown. Never silently drops content."""
+    tag = node.tag
+    if tag == "para":
+        return render_children(node).strip() + "\n\n"
+    if tag == "computeroutput":
+        return "`" + render_children(node).strip() + "`"
+    if tag == "emphasis":
+        return "*" + render_children(node).strip() + "*"
+    if tag == "bold":
+        return "**" + render_children(node).strip() + "**"
+    if tag in _SECT_TAGS:
+        return _render_section(node)
+    if tag == "ref":
+        return render_children(node)
+    if tag == "ulink":
+        return "[%s](%s)" % (render_children(node).strip(), node.get("url", ""))
+    if tag == "programlisting":
+        return _render_programlisting(node)
+    if tag == "itemizedlist":
+        return _render_list(node, ordered=False)
+    if tag == "orderedlist":
+        return _render_list(node, ordered=True)
+    if tag == "linebreak":
+        return "\n"
+    if tag == "sp":
+        return " "
+    if tag == "title":
+        # standalone title (not consumed by a section) -> plain text
+        return render_children(node)
+    # Unknown tag: render its children so nothing is silently lost.
+    return render_children(node)
+
+
+def _collapse(text):
+    # Drop trailing whitespace and whitespace-only lines (the latter would
+    # otherwise render as spurious markdown indented code blocks; they come
+    # from indentation inside empty Doxygen description elements).
+    text = "\n".join(
+        "" if not line.strip() else line.rstrip() for line in text.split("\n")
+    )
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def render_description(*nodes):
+    """Render the given brief/detailed elements (skipping ``None``)."""
+    parts = []
+    for node in nodes:
+        if node is None:
+            continue
+        parts.append(render_children(node))
+    return _collapse("\n\n".join(parts))

--- a/docs/plans/2026-05-20-llm-docs-design.md
+++ b/docs/plans/2026-05-20-llm-docs-design.md
@@ -1,0 +1,104 @@
+# Design: LLM-friendly documentation for tgen
+
+Date: 2026-05-20
+
+## Problem
+
+`tgen` ships rich human-facing docs built by Doxygen (HTML on GitHub Pages). We
+want to *additionally* publish an LLM-friendly markdown version so an agent can
+be handed a single link, navigate the docs by fetching, and learn to use the
+library correctly. The existing HTML docs must stay exactly as they are.
+
+## Requirements (decided during brainstorming)
+
+- **Scope: full reference.** Capture both doc sources — the hand-written `.dox`
+  group pages (prose + `cpp` examples) *and* the inline per-function API
+  comments in `single_include/tgen.h`. A `.dox`-only converter would miss the
+  inline API docs, so this is generated from Doxygen's unified representation.
+- **Structure: index + per-module leaves** (the `llms.txt` convention). A small
+  index links to one markdown file per module; an agent fetches the index, sees
+  the map, and drills into only the leaves it needs.
+- **Hosting: GitHub Pages.** Output lands in `docs/build`, which the existing
+  `docs.yml` workflow already deploys, giving stable
+  `rsalesc.github.io/tgen/...` URLs. Pages serves `.md`/`.txt` as raw text
+  (`.nojekyll` is already set), which is what an agent wants when fetching.
+
+## Approach
+
+Reuse the canonical Doxygen representation rather than re-parsing sources by
+hand.
+
+1. **Second Doxygen run for XML.** A new `make llms` target runs Doxygen again
+   with `GENERATE_XML=YES`, `GENERATE_HTML=NO`, `GENERATE_LATEX=NO` into a
+   throwaway `docs/build/xml` dir (same `@INCLUDE = Doxyfile` + override pipe
+   pattern the existing `doc` target uses). The HTML build is untouched.
+2. **Self-contained converter.** `docs/llms_gen.py` (Python 3 stdlib only —
+   `xml.etree`, no pip/node deps, matching the project's minimal-deps ethos)
+   walks the XML and emits markdown.
+3. **Cleanup.** The `xml` temp dir is deleted after conversion so raw XML never
+   publishes to Pages.
+
+`make llms` is wired into `make doc` so the two always build together locally,
+and CI (`docs.yml`) runs `make doc llms` before uploading the Pages artifact.
+
+## Output layout
+
+```
+docs/build/
+  llms.txt              # index
+  llms/
+    base.md  opts.md  list.md  pair.md  permutation.md
+    str.md   tree.md   graph.md  math.md  hack.md  misc.md
+```
+
+- **`llms.txt`** — `llms.txt`-convention index: an `H1` title, a short summary
+  blockquote (mental model: generator -> value -> operation pipeline), then a
+  list of modules. Each entry shows the module's one-line `@brief` and an
+  **absolute** `https://<base>/llms/<mod>.md` URL. The base URL is a make
+  variable (default `rsalesc.github.io/tgen`) so the upstream fork can override
+  it.
+- **`llms/<mod>.md`** — per group: the group overview + examples, then every
+  member (free functions from the group's `sectiondef`s and members of
+  `innerclass` structs like `list`, `str`, `wtree`, `wgraph`). Each member
+  renders signature, template params, params, returns, and description.
+
+## Markdown rendering rules (Doxygen XML -> markdown)
+
+Walk `detaileddescription`/`briefdescription` nodes:
+
+| XML node | Markdown |
+|---|---|
+| `<para>` | paragraph |
+| `<programlisting>` (codeline/highlight) | ` ```cpp ` fenced block |
+| `<computeroutput>` (`@tt{}`, `@pname{}`) | inline `` `code` `` |
+| `<itemizedlist>/<listitem>` | `- ` bullets |
+| `<emphasis>` / `<bold>` | `*italic*` / `**bold**` |
+| `<heading level=n>` (e.g. `### Examples`) | `#`*n* heading |
+| `<ref>` | link text (kept inline) |
+| `<ulink url=...>` | `[text](url)` |
+| `<parameterlist kind="param"/"templateparam">` | params section |
+| `<simplesect kind="return">` | `**Returns:**` line |
+
+Member signatures are built from `<type>`, `<name>`, and `<argsstring>` (or
+reconstructed from `<param>` children).
+
+## Validation
+
+The script self-checks its output and exits non-zero if:
+
+- any unconverted `@command{...}` Doxygen markup leaks into the markdown, or
+- the index or any of the 11 expected module files is missing.
+
+No new test framework is introduced (consistent with the gtest-only C++ suite).
+CI's existing docs build will surface failures.
+
+## Local development note
+
+Doxygen is not installed on the dev machine; install via `brew install doxygen`
+to develop/test the converter. XML format is stable across versions, so the
+brew version is fine even though CI pins 1.14.0.
+
+## Out of scope
+
+- Changing the existing HTML docs in any way.
+- A combined single-file (`llms-full.txt`) dump — can be added later if needed.

--- a/docs/plans/2026-05-20-llm-docs.md
+++ b/docs/plans/2026-05-20-llm-docs.md
@@ -1,0 +1,748 @@
+# LLM-friendly Documentation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Generate an LLM-friendly markdown doc tree (`llms.txt` index + one `.md` per module) from Doxygen XML and publish it to GitHub Pages alongside the untouched HTML docs.
+
+**Architecture:** A new `make llms` target runs Doxygen a second time emitting XML only (HTML build untouched) into a throwaway `docs/build/xml`. A stdlib-only Python converter `docs/llms_gen.py` walks that XML and writes `docs/build/llms.txt` + `docs/build/llms/<module>.md`, then the XML temp dir is deleted. `make llms` is wired into `make doc` and CI runs `make doc llms` before the existing Pages upload.
+
+**Tech Stack:** Doxygen 1.14 (XML generator), Python 3 stdlib (`xml.etree.ElementTree`, `unittest`), GNU make, GitHub Actions.
+
+Design doc: `docs/plans/2026-05-20-llm-docs-design.md`
+
+---
+
+## Conventions for this plan
+
+- All commands run from the repo root `/Users/rsalesc/Dev/tgen` unless noted.
+- Python tests use stdlib `unittest` (no pip deps). Test file: `docs/test_llms_gen.py`.
+- Run a single test: `python3 -m unittest docs.test_llms_gen.TestRender.test_name -v`
+  (run from repo root; `docs/__init__.py` is **not** wanted — instead run
+  `cd docs && python3 -m unittest test_llms_gen.TestRender.test_name -v`).
+- Commit after each task. Branch is already `llm-docs`.
+
+---
+
+### Task 0: Install Doxygen locally and capture real XML to develop against
+
+**Files:** none (setup + scratch output).
+
+**Step 1: Install doxygen**
+
+Run: `brew install doxygen graphviz`
+Expected: doxygen on PATH. Verify: `doxygen --version` prints `1.x`.
+
+If `brew` is unavailable, ask the user to install doxygen; the converter cannot
+be developed without sample XML.
+
+**Step 2: Generate XML once to inspect the real schema**
+
+Run:
+```bash
+cd docs && { printf '%s\n' '@INCLUDE = Doxyfile' \
+  'GENERATE_HTML=NO' 'GENERATE_XML=YES' 'GENERATE_LATEX=NO' \
+  'GENERATE_DOCBOOK=NO' 'XML_OUTPUT=build/xml' 'OUTPUT_DIRECTORY=.'; } | doxygen -
+```
+Expected: `docs/build/xml/` contains `index.xml`, `group__list.xml`,
+`structtgen_1_1list.xml`, etc.
+
+**Step 3: Confirm the schema assumptions used by later tasks**
+
+Inspect and confirm (adjust later code if reality differs):
+- Group files are named `group__<name>.xml`.
+- `index.xml` lists `<compound kind="group">` entries with `<name>` and `refid`.
+- A group `<compounddef>` has `<compoundname>`, `<title>`, `<briefdescription>`,
+  `<detaileddescription>`, `<innerclass refid=...>`, and `<sectiondef><memberdef>`.
+- Members have `<definition>`, `<argsstring>`, `<name>`, `<param>`,
+  `<briefdescription>`, `<detaileddescription>`.
+- Rich text uses `<para>`, `<programlisting>/<codeline>/<highlight>/<sp/>`,
+  `<computeroutput>`, `<itemizedlist>/<listitem>`, `<emphasis>`, `<bold>`,
+  `<heading level=N>`, `<ref>`, `<ulink url=>`, `<parameterlist>`,
+  `<simplesect kind="return">`.
+
+Run: `ls docs/build/xml | head` and open `docs/build/xml/group__list.xml`.
+
+**Step 4: Keep this scratch XML for tests but do not commit it**
+
+Run: `echo 'docs/build/' ; grep -q '^docs/build' .gitignore || echo "check .gitignore"`
+Expected: `docs/build` is already ignored (it is the HTML build dir). Confirm
+with `cat .gitignore`. No commit in this task.
+
+---
+
+### Task 1: Inline rich-text renderer (`render_para`) with unit tests
+
+**Files:**
+- Create: `docs/llms_gen.py`
+- Create: `docs/test_llms_gen.py`
+
+**Step 1: Write failing tests for the inline renderer**
+
+Create `docs/test_llms_gen.py`:
+```python
+import unittest
+import xml.etree.ElementTree as ET
+import llms_gen as L
+
+
+def parse(xml):
+    return ET.fromstring(xml)
+
+
+class TestRender(unittest.TestCase):
+    def test_plain_para(self):
+        node = parse("<detaileddescription><para>Hello world.</para></detaileddescription>")
+        self.assertEqual(L.render_description(node).strip(), "Hello world.")
+
+    def test_computeroutput_inline_code(self):
+        node = parse("<para>See <computeroutput>tgen::list</computeroutput> here.</para>")
+        self.assertEqual(L.render_node(node).strip(), "See `tgen::list` here.")
+
+    def test_emphasis_and_bold(self):
+        node = parse("<para><emphasis>i</emphasis> and <bold>b</bold></para>")
+        self.assertEqual(L.render_node(node).strip(), "*i* and **b**")
+
+    def test_programlisting_fenced_cpp(self):
+        xml = ("<para><programlisting filename='.cpp'>"
+               "<codeline><highlight class='normal'>int<sp/>x<sp/>=<sp/>1;</highlight></codeline>"
+               "<codeline><highlight class='normal'>x++;</highlight></codeline>"
+               "</programlisting></para>")
+        out = L.render_node(parse(xml))
+        self.assertIn("```cpp", out)
+        self.assertIn("int x = 1;", out)
+        self.assertIn("x++;", out)
+        self.assertIn("```", out.rsplit("int", 1)[0] + "```")
+
+    def test_itemized_list(self):
+        xml = ("<para><itemizedlist>"
+               "<listitem><para>one</para></listitem>"
+               "<listitem><para>two</para></listitem>"
+               "</itemizedlist></para>")
+        out = L.render_node(parse(xml))
+        self.assertIn("- one", out)
+        self.assertIn("- two", out)
+
+    def test_heading(self):
+        node = parse("<para><heading level='3'>Examples</heading></para>")
+        self.assertEqual(L.render_node(node).strip(), "### Examples")
+
+    def test_ref_keeps_text(self):
+        node = parse("<para>call <ref refid='x' kindref='member'>gen</ref>()</para>")
+        self.assertEqual(L.render_node(node).strip(), "call gen()")
+
+    def test_ulink(self):
+        node = parse("<para>see <ulink url='http://x'>here</ulink></para>")
+        self.assertEqual(L.render_node(node).strip(), "see [here](http://x)")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd docs && python3 -m unittest test_llms_gen -v`
+Expected: FAIL/ERROR — `llms_gen` has no `render_node`/`render_description`.
+
+**Step 3: Implement the inline renderer**
+
+Create `docs/llms_gen.py`:
+```python
+#!/usr/bin/env python3
+"""Generate an LLM-friendly markdown doc tree from Doxygen XML.
+
+Reads a Doxygen XML output directory and writes:
+  <out>/llms.txt          -- index linking to per-module files
+  <out>/llms/<module>.md  -- one markdown file per @defgroup
+
+Stdlib only. See docs/plans/2026-05-20-llm-docs-design.md.
+"""
+import argparse
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+
+# ----- inline / block rich-text rendering -------------------------------------
+
+def _text(s):
+    return s or ""
+
+
+def render_children(node):
+    """Render a node's text + children + tails in document order."""
+    out = [_text(node.text)]
+    for child in node:
+        out.append(render_node(child))
+        out.append(_text(child.tail))
+    return "".join(out)
+
+
+def render_node(node):
+    """Render a single rich-text element to markdown."""
+    tag = node.tag
+    if tag in ("para",):
+        inner = render_children(node).strip()
+        return inner + "\n\n" if inner else ""
+    if tag == "computeroutput":
+        return "`" + render_children(node).strip() + "`"
+    if tag == "emphasis":
+        return "*" + render_children(node).strip() + "*"
+    if tag == "bold":
+        return "**" + render_children(node).strip() + "**"
+    if tag == "heading":
+        level = int(node.get("level", "2"))
+        return "\n" + "#" * level + " " + render_children(node).strip() + "\n"
+    if tag == "ref":
+        return render_children(node)
+    if tag == "ulink":
+        return "[" + render_children(node).strip() + "](" + node.get("url", "") + ")"
+    if tag == "programlisting":
+        return _render_programlisting(node)
+    if tag == "itemizedlist":
+        return _render_list(node, ordered=False)
+    if tag == "orderedlist":
+        return _render_list(node, ordered=True)
+    if tag == "parameterlist":
+        return _render_parameterlist(node)
+    if tag == "simplesect":
+        return _render_simplesect(node)
+    if tag in ("linebreak",):
+        return "\n"
+    if tag in ("sp",):
+        return " "
+    # Unknown wrapper: render children so we never silently drop content.
+    return render_children(node)
+
+
+def _render_programlisting(node):
+    lines = []
+    for codeline in node.findall("codeline"):
+        lines.append(_codeline_text(codeline))
+    code = "\n".join(lines).rstrip()
+    return "\n```cpp\n" + code + "\n```\n\n"
+
+
+def _codeline_text(codeline):
+    parts = [_text(codeline.text)]
+    for child in codeline:
+        if child.tag == "sp":
+            parts.append(" ")
+        elif child.tag == "highlight":
+            parts.append(_highlight_text(child))
+        else:
+            parts.append(render_children(child))
+        parts.append(_text(child.tail))
+    return "".join(parts)
+
+
+def _highlight_text(node):
+    parts = [_text(node.text)]
+    for child in node:
+        if child.tag == "sp":
+            parts.append(" ")
+        else:
+            parts.append(_text(child.text) + render_children(child))
+        parts.append(_text(child.tail))
+    return "".join(parts)
+
+
+def _render_list(node, ordered):
+    out = ["\n"]
+    for i, item in enumerate(node.findall("listitem"), 1):
+        marker = f"{i}. " if ordered else "- "
+        body = "".join(render_node(c) for c in item).strip()
+        out.append(marker + body + "\n")
+    out.append("\n")
+    return "".join(out)
+
+
+def _render_parameterlist(node):
+    kind = node.get("kind", "param")
+    title = {"param": "Parameters", "templateparam": "Template parameters",
+             "retval": "Return values", "exception": "Exceptions"}.get(kind, kind)
+    rows = []
+    for item in node.findall("parameteritem"):
+        names = [n.text or "" for n in item.iter("parametername")]
+        desc = "".join(render_node(p) for p in item.iter("parameterdescription")).strip()
+        rows.append("- `" + ", ".join(filter(None, names)) + "` — " + desc)
+    if not rows:
+        return ""
+    return "\n**" + title + ":**\n\n" + "\n".join(rows) + "\n\n"
+
+
+def _render_simplesect(node):
+    kind = node.get("kind", "")
+    label = {"return": "Returns", "note": "Note", "warning": "Warning",
+             "see": "See also", "since": "Since"}.get(kind, kind.capitalize())
+    body = render_children(node).strip()
+    return "\n**" + label + ":** " + body + "\n\n"
+
+
+def render_description(*nodes):
+    """Render brief/detailed description elements (may be None)."""
+    out = []
+    for node in nodes:
+        if node is not None:
+            out.append(render_children(node))
+    text = "".join(out)
+    # collapse 3+ newlines
+    return re.sub(r"\n{3,}", "\n\n", text).strip()
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd docs && python3 -m unittest test_llms_gen -v`
+Expected: PASS (8 tests).
+
+**Step 5: Commit**
+
+```bash
+git add docs/llms_gen.py docs/test_llms_gen.py
+git commit -m "Add Doxygen-XML rich-text to markdown renderer"
+```
+
+---
+
+### Task 2: Parameter & return rendering integration test
+
+**Files:**
+- Modify: `docs/test_llms_gen.py`
+
+**Step 1: Add a failing test for parameterlist + return**
+
+Append to `TestRender`:
+```python
+    def test_parameterlist_and_return(self):
+        xml = ("<detaileddescription><para>Builds a list."
+               "<parameterlist kind='param'>"
+               "<parameteritem><parameternamelist><parametername>size</parametername></parameternamelist>"
+               "<parameterdescription><para>length</para></parameterdescription></parameteritem>"
+               "</parameterlist>"
+               "<simplesect kind='return'><para>a generator</para></simplesect>"
+               "</para></detaileddescription>")
+        out = L.render_description(parse(xml))
+        self.assertIn("**Parameters:**", out)
+        self.assertIn("`size` — length", out)
+        self.assertIn("**Returns:** a generator", out)
+```
+
+**Step 2: Run to verify pass or fail**
+
+Run: `cd docs && python3 -m unittest test_llms_gen.TestRender.test_parameterlist_and_return -v`
+Expected: PASS (logic exists from Task 1). If it fails, fix
+`_render_parameterlist`/`_render_simplesect` until it passes.
+
+**Step 3: Commit**
+
+```bash
+git add docs/test_llms_gen.py
+git commit -m "Test parameterlist and return rendering"
+```
+
+---
+
+### Task 3: Member and group extraction -> module markdown
+
+**Files:**
+- Modify: `docs/llms_gen.py`
+- Modify: `docs/test_llms_gen.py`
+
+**Step 1: Write failing tests for member + group rendering**
+
+Add a new test class to `docs/test_llms_gen.py`:
+```python
+class TestGroup(unittest.TestCase):
+    def test_render_member_signature(self):
+        xml = ("<memberdef kind='function'>"
+               "<type>void</type>"
+               "<definition>tgen::list::reverse</definition>"
+               "<argsstring>()</argsstring>"
+               "<name>reverse</name>"
+               "<briefdescription><para>Reverses the list.</para></briefdescription>"
+               "<detaileddescription></detaileddescription>"
+               "</memberdef>")
+        out = L.render_member(parse(xml))
+        self.assertIn("tgen::list::reverse()", out)
+        self.assertIn("Reverses the list.", out)
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `cd docs && python3 -m unittest test_llms_gen.TestGroup -v`
+Expected: FAIL — `render_member` not defined.
+
+**Step 3: Implement member + group + struct rendering**
+
+Append to `docs/llms_gen.py`:
+```python
+# ----- structural rendering ---------------------------------------------------
+
+def _member_signature(m):
+    rtype = render_children(m.find("type")).strip() if m.find("type") is not None else ""
+    definition = (m.findtext("definition") or m.findtext("name") or "").strip()
+    args = (m.findtext("argsstring") or "").strip()
+    sig = (rtype + " " if rtype else "") + definition + args
+    return sig.strip()
+
+
+def render_member(m):
+    name = (m.findtext("name") or "").strip()
+    sig = _member_signature(m)
+    desc = render_description(m.find("briefdescription"), m.find("detaileddescription"))
+    out = [f"#### `{name}`\n\n", "```cpp\n" + sig + "\n```\n\n"]
+    if desc:
+        out.append(desc + "\n\n")
+    return "".join(out)
+
+
+def _load(xml_dir, refid):
+    path = os.path.join(xml_dir, refid + ".xml")
+    if not os.path.exists(path):
+        return None
+    return ET.parse(path).getroot().find("compounddef")
+
+
+def render_compound_members(compounddef):
+    """Render every documented function memberdef under a compounddef."""
+    out = []
+    for sec in compounddef.findall("sectiondef"):
+        for m in sec.findall("memberdef"):
+            if m.get("kind") == "function":
+                out.append(render_member(m))
+    return "".join(out)
+
+
+def render_group(xml_dir, compounddef):
+    title = (compounddef.findtext("title") or compounddef.findtext("compoundname") or "").strip()
+    out = [f"# {title}\n\n"]
+    desc = render_description(compounddef.find("briefdescription"),
+                              compounddef.find("detaileddescription"))
+    if desc:
+        out.append(desc + "\n\n")
+
+    members = render_compound_members(compounddef)
+    if members:
+        out.append("## API\n\n")
+        out.append(members)
+
+    for inner in compounddef.findall("innerclass"):
+        sub = _load(xml_dir, inner.get("refid"))
+        if sub is None:
+            continue
+        sub_name = (sub.findtext("compoundname") or inner.text or "").strip()
+        out.append(f"## `{sub_name}`\n\n")
+        sub_desc = render_description(sub.find("briefdescription"),
+                                      sub.find("detaileddescription"))
+        if sub_desc:
+            out.append(sub_desc + "\n\n")
+        out.append(render_compound_members(sub))
+
+    return re.sub(r"\n{3,}", "\n\n", "".join(out)).strip() + "\n"
+
+
+def group_brief(compounddef):
+    return render_description(compounddef.find("briefdescription")).replace("\n", " ").strip()
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd docs && python3 -m unittest test_llms_gen -v`
+Expected: PASS (all tests).
+
+**Step 5: Commit**
+
+```bash
+git add docs/llms_gen.py docs/test_llms_gen.py
+git commit -m "Render members, groups, and inner structs to markdown"
+```
+
+---
+
+### Task 4: Index discovery + `main()` + self-validation
+
+**Files:**
+- Modify: `docs/llms_gen.py`
+
+**Step 1: Implement index walk, file writing, validation, and CLI**
+
+Append to `docs/llms_gen.py`:
+```python
+# ----- driver -----------------------------------------------------------------
+
+def discover_groups(xml_dir):
+    """Return list of (name, refid) for kind='group', in index order."""
+    index = ET.parse(os.path.join(xml_dir, "index.xml")).getroot()
+    groups = []
+    for comp in index.findall("compound"):
+        if comp.get("kind") == "group":
+            groups.append((comp.findtext("name"), comp.get("refid")))
+    return groups
+
+
+UNCONVERTED = re.compile(r"@[a-zA-Z]+\{")
+
+
+def generate(xml_dir, out_dir, base_url):
+    leaves_dir = os.path.join(out_dir, "llms")
+    os.makedirs(leaves_dir, exist_ok=True)
+
+    entries = []  # (name, brief)
+    for name, refid in discover_groups(xml_dir):
+        compounddef = _load(xml_dir, refid)
+        if compounddef is None:
+            continue
+        md = render_group(xml_dir, compounddef)
+        if UNCONVERTED.search(md):
+            sys.exit(f"llms_gen: unconverted Doxygen markup in '{name}.md': "
+                     f"{UNCONVERTED.search(md).group(0)}")
+        with open(os.path.join(leaves_dir, name + ".md"), "w") as f:
+            f.write(md)
+        entries.append((name, group_brief(compounddef)))
+
+    _write_index(out_dir, base_url, entries)
+    _validate(out_dir, entries)
+    return entries
+
+
+def _write_index(out_dir, base_url, entries):
+    base = base_url.rstrip("/")
+    lines = [
+        "# tgen",
+        "",
+        "> tgen is a header-only C++17 library for writing random testcase "
+        "generators with declarative constraints, provably uniform sampling, "
+        "and adversarial (\"hack\") generation. The core pipeline is "
+        "**generator -> .gen() -> value operations**: a generator describes a "
+        "set of valid objects under constraints, `.gen()` samples one uniformly "
+        "at random, and value operations mutate the result. The entire library "
+        "is one header: `single_include/tgen.h`.",
+        "",
+        "## Modules",
+        "",
+    ]
+    for name, brief in entries:
+        suffix = f" — {brief}" if brief else ""
+        lines.append(f"- [{name}]({base}/llms/{name}.md){suffix}")
+    lines += [
+        "",
+        "## Source",
+        "",
+        f"- [Full header source]({base}/../single_include/tgen.h) — exact signatures live here.",
+        "",
+    ]
+    with open(os.path.join(out_dir, "llms.txt"), "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+EXPECTED_MODULES = {"base", "opts", "list", "pair", "permutation",
+                    "str", "tree", "graph", "math", "hack", "misc"}
+
+
+def _validate(out_dir, entries):
+    names = {n for n, _ in entries}
+    missing = EXPECTED_MODULES - names
+    if missing:
+        sys.exit(f"llms_gen: missing expected modules: {sorted(missing)}")
+    if not os.path.exists(os.path.join(out_dir, "llms.txt")):
+        sys.exit("llms_gen: index llms.txt was not written")
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--xml", required=True, help="Doxygen XML output dir")
+    p.add_argument("--out", required=True, help="output dir (gets llms.txt + llms/)")
+    p.add_argument("--base-url", default="https://rsalesc.github.io/tgen",
+                   help="absolute base URL for links in llms.txt")
+    args = p.parse_args(argv)
+    entries = generate(args.xml, args.out, args.base_url)
+    print(f"llms_gen: wrote llms.txt + {len(entries)} module files to {args.out}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+**Step 2: Smoke-run against the Task 0 scratch XML**
+
+Run:
+```bash
+cd docs && python3 llms_gen.py --xml build/xml --out build && \
+  echo "---INDEX---" && cat build/llms.txt && \
+  echo "---LIST---" && head -60 build/llms/list.md
+```
+Expected: index lists all 11 modules with briefs; `list.md` shows the Lists
+overview + examples + per-method API. No "unconverted markup" error.
+
+**Step 3: Eyeball for rendering defects**
+
+Check `build/llms/graph.md`, `build/llms/str.md`, `build/llms/hack.md` for:
+- code fences are ```cpp and contain real code,
+- no leftover `@tt{`/`@pname{`/`@ref` literals,
+- params/returns formatted.
+Fix renderer edge cases if found (re-run Task 1 tests after any change).
+
+**Step 4: Commit**
+
+```bash
+git add docs/llms_gen.py
+git commit -m "Add index generation, CLI driver, and output validation"
+```
+
+---
+
+### Task 5: Wire `make llms` and fold it into `make doc`
+
+**Files:**
+- Modify: `makefile`
+
+**Step 1: Add the `llms` target**
+
+Add a make variable near the other DOC vars (top of `makefile`):
+```make
+LLM_BASE_URL ?= https://rsalesc.github.io/tgen
+```
+
+Add `llms` to the `.PHONY` line, then add this target after the `doc` target
+(uses the same override-pipe pattern as `doc`, writes XML to a temp dir, and
+deletes it after conversion):
+```make
+# LLM-friendly markdown docs: second Doxygen run (XML only) + python converter.
+# Output: $(DOC_HTML_DIR)/llms.txt and $(DOC_HTML_DIR)/llms/*.md
+llms:
+	cd $(DOC_SRC_DIR) && { \
+	printf '%s\n' '@INCLUDE = Doxyfile' 'GENERATE_HTML=NO' 'GENERATE_XML=YES' \
+		'GENERATE_LATEX=NO' 'GENERATE_DOCBOOK=NO' \
+		'XML_OUTPUT=build/xml' 'OUTPUT_DIRECTORY=.' \
+		'NUM_PROC_THREADS = $(NPROCS)' 'DOT_NUM_THREADS = $(NPROCS)'; \
+	} | doxygen -
+	python3 $(DOC_SRC_DIR)/llms_gen.py \
+		--xml $(DOC_BUILD_DIR)/xml \
+		--out $(DOC_HTML_DIR) \
+		--base-url '$(LLM_BASE_URL)'
+	rm -rf $(DOC_BUILD_DIR)/xml
+```
+
+**Step 2: Fold `llms` into `doc`**
+
+So the two always build together locally, add `llms` as the final action of the
+`doc` target. Append after the existing `.nojekyll` line in the `doc` recipe:
+```make
+	$(MAKE) llms
+```
+(Use a recursive `$(MAKE) llms` so it runs after HTML assets are in place.)
+
+**Step 3: Update `make help` text**
+
+Edit the Docs help line to mention llms:
+```make
+	@echo "Docs:      make doc | doc-rebuild | opendoc | clean-doc | llms   (doc also builds llms)"
+```
+
+**Step 4: Build and verify end-to-end**
+
+Run: `make clean-doc doc`
+Expected: HTML builds as before AND `docs/build/llms.txt` + `docs/build/llms/`
+exist; `docs/build/xml` is gone.
+
+Run: `test -f docs/build/llms.txt && ls docs/build/llms && test ! -d docs/build/xml && echo OK`
+Expected: `OK` and the 11 module files listed.
+
+**Step 5: Commit**
+
+```bash
+git add makefile
+git commit -m "Add make llms target and fold it into make doc"
+```
+
+---
+
+### Task 6: Wire LLM docs into the Pages CI
+
+**Files:**
+- Modify: `.github/workflows/docs.yml`
+
+**Step 1: Ensure python3 is present and run the converter in CI**
+
+The GitHub `ubuntu-latest` runner already has python3. Change the build step so
+it also produces the llms files. Edit the `Build documentation` step:
+```yaml
+      - name: Build documentation
+        run: make doc
+```
+to:
+```yaml
+      - name: Build documentation
+        run: make doc llms
+```
+(`make doc` already runs `llms` via Task 5, but listing it explicitly is
+harmless and self-documenting; keep `make doc llms`.)
+
+**Step 2: Verify the workflow still uploads `docs/build`**
+
+Confirm the `upload-pages-artifact` step still has `path: docs/build` (no change
+needed — the llms files live there).
+
+**Step 3: Commit**
+
+```bash
+git add .github/workflows/docs.yml
+git commit -m "Generate LLM docs in Pages CI"
+```
+
+---
+
+### Task 7: Final end-to-end verification and lint
+
+**Files:** none (verification).
+
+**Step 1: Full clean rebuild**
+
+Run: `make doc-rebuild`
+Expected: completes; HTML + `llms.txt` + `llms/*.md` present; no `xml` dir.
+
+**Step 2: Confirm no Doxygen markup leaked anywhere**
+
+Run: `! grep -rEl '@(tt|pname|ref|ingroup|defgroup|brief|param|tparam)\b' docs/build/llms* && echo CLEAN`
+Expected: `CLEAN`.
+
+**Step 3: Confirm the index links resolve to existing leaf files**
+
+Run:
+```bash
+python3 - <<'PY'
+import re, os
+base = "docs/build"
+txt = open(os.path.join(base, "llms.txt")).read()
+mods = re.findall(r'/llms/([a-z]+)\.md', txt)
+missing = [m for m in mods if not os.path.exists(f"{base}/llms/{m}.md")]
+print("MISSING", missing or "none")
+PY
+```
+Expected: `MISSING none`.
+
+**Step 4: Run the converter unit tests once more**
+
+Run: `cd docs && python3 -m unittest test_llms_gen -v`
+Expected: all PASS.
+
+**Step 5: Run C++ lint check (ensure nothing unrelated broke)**
+
+Run: `make lint-check`
+Expected: passes (we touched no C++; this guards the commit).
+
+**Step 6: Final commit if anything pending**
+
+```bash
+git status
+# commit any stragglers, otherwise done
+```
+
+---
+
+## Notes / follow-ups (out of scope)
+
+- The upstream fork can override links with `make llms LLM_BASE_URL=https://brunomaletta.github.io/tgen`.
+- A combined `llms-full.txt` dump could be added later if an agent prefers one fetch.
+- After merge, GitHub Pages settings must have Pages enabled for `rsalesc/tgen` for the URL to resolve (repo setting, not code).

--- a/docs/test_llms_gen.py
+++ b/docs/test_llms_gen.py
@@ -1,0 +1,121 @@
+"""Unit tests for ``llms_gen`` (the Doxygen-XML -> markdown converter).
+
+Run from inside ``docs/``::
+
+    python3 -m unittest test_llms_gen -v
+
+Stdlib only (``unittest`` + ``xml.etree``); no pip dependencies.
+"""
+
+import unittest
+import xml.etree.ElementTree as ET
+
+import llms_gen
+
+
+def el(xml):
+    """Parse an XML snippet into an Element."""
+    return ET.fromstring(xml)
+
+
+class RenderInlineTest(unittest.TestCase):
+    def test_plain_para(self):
+        out = llms_gen.render_node(el("<para>Hello world.</para>"))
+        self.assertIn("Hello world.", out)
+
+    def test_computeroutput_inline_code(self):
+        out = llms_gen.render_node(el("<computeroutput>foo()</computeroutput>"))
+        self.assertEqual("`foo()`", out.strip())
+
+    def test_emphasis(self):
+        out = llms_gen.render_node(el("<emphasis>italic</emphasis>"))
+        self.assertEqual("*italic*", out.strip())
+
+    def test_bold(self):
+        out = llms_gen.render_node(el("<bold>strong</bold>"))
+        self.assertEqual("**strong**", out.strip())
+
+    def test_programlisting_fenced_cpp(self):
+        xml = (
+            '<programlisting filename=".cpp">'
+            '<codeline><highlight class="keyword">auto</highlight>'
+            '<highlight class="normal"><sp/>x<sp/>=<sp/>1;</highlight></codeline>'
+            '<codeline><highlight class="normal">return<sp/>x;</highlight></codeline>'
+            "</programlisting>"
+        )
+        out = llms_gen.render_node(el(xml))
+        self.assertIn("```cpp", out)
+        self.assertIn("auto x = 1;", out)
+        self.assertIn("return x;", out)
+        self.assertTrue(out.rstrip().endswith("```"))
+
+    def test_itemizedlist(self):
+        xml = (
+            "<itemizedlist>"
+            "<listitem><para>one</para></listitem>"
+            "<listitem><para>two</para></listitem>"
+            "</itemizedlist>"
+        )
+        out = llms_gen.render_node(el(xml))
+        self.assertIn("- one", out)
+        self.assertIn("- two", out)
+
+    def test_orderedlist(self):
+        xml = (
+            "<orderedlist>"
+            "<listitem><para>first</para></listitem>"
+            "<listitem><para>second</para></listitem>"
+            "</orderedlist>"
+        )
+        out = llms_gen.render_node(el(xml))
+        self.assertIn("1. first", out)
+        self.assertIn("2. second", out)
+
+    def test_section_heading_with_title(self):
+        # Doxygen wraps markdown headings as nested sect elements; the
+        # innermost one carries the title.
+        xml = "<sect1><title>Examples</title><para>body text</para></sect1>"
+        out = llms_gen.render_node(el(xml))
+        self.assertIn("## Examples", out)
+        self.assertIn("body text", out)
+
+    def test_nested_section_wrappers(self):
+        xml = (
+            "<sect1><sect2><sect3>"
+            "<title>Complexity</title><para>O(1).</para>"
+            "</sect3></sect2></sect1>"
+        )
+        out = llms_gen.render_node(el(xml))
+        # innermost is sect3 -> level 4 heading
+        self.assertIn("#### Complexity", out)
+        self.assertIn("O(1).", out)
+
+    def test_ref_keeps_text(self):
+        out = llms_gen.render_node(
+            el('<ref refid="x" kindref="member">tgen::list</ref>')
+        )
+        self.assertEqual("tgen::list", out.strip())
+
+    def test_ulink(self):
+        out = llms_gen.render_node(
+            el('<ulink url="https://example.com">site</ulink>')
+        )
+        self.assertEqual("[site](https://example.com)", out.strip())
+
+    def test_render_description_collapses_blank_lines(self):
+        a = el("<briefdescription><para>Brief.</para></briefdescription>")
+        b = el("<detaileddescription><para>Detail.</para></detaileddescription>")
+        out = llms_gen.render_description(a, b)
+        self.assertIn("Brief.", out)
+        self.assertIn("Detail.", out)
+        self.assertNotIn("\n\n\n", out)
+        self.assertEqual(out, out.strip())
+
+    def test_render_description_skips_none(self):
+        b = el("<detaileddescription><para>Only detail.</para></detaileddescription>")
+        out = llms_gen.render_description(None, b)
+        self.assertIn("Only detail.", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/test_llms_gen.py
+++ b/docs/test_llms_gen.py
@@ -7,6 +7,8 @@ Run from inside ``docs/``::
 Stdlib only (``unittest`` + ``xml.etree``); no pip dependencies.
 """
 
+import os
+import tempfile
 import unittest
 import xml.etree.ElementTree as ET
 
@@ -204,6 +206,41 @@ class ParameterAndSimpleSectTest(unittest.TestCase):
         )
         out = llms_gen.render_description(None, el(xml))
         self.assertIn("**Note:** be careful", out)
+
+
+class SmokeXmlTest(unittest.TestCase):
+    XML_DIR = os.path.join(os.path.dirname(__file__), "build", "xml")
+
+    def setUp(self):
+        if not os.path.isdir(self.XML_DIR):
+            self.skipTest("real XML not generated at build/xml")
+
+    def test_discover_groups(self):
+        groups = llms_gen.discover_groups(self.XML_DIR)
+        names = [n for n, _ in groups]
+        for expected in llms_gen.EXPECTED_MODULES:
+            self.assertIn(expected, names)
+
+    def test_generate_full(self):
+        with tempfile.TemporaryDirectory() as out:
+            llms_gen.generate(self.XML_DIR, out, "https://example.com/tgen/")
+            index = os.path.join(out, "llms.txt")
+            self.assertTrue(os.path.isfile(index))
+            with open(index) as f:
+                idx = f.read()
+            self.assertIn("# tgen", idx)
+            self.assertIn("## Modules", idx)
+            for expected in llms_gen.EXPECTED_MODULES:
+                self.assertTrue(
+                    os.path.isfile(os.path.join(out, "llms", expected + ".md")),
+                    expected,
+                )
+            with open(os.path.join(out, "llms", "list.md")) as f:
+                listmd = f.read()
+            self.assertIn("```cpp", listmd)
+            self.assertNotIn("@tt{", listmd)
+            self.assertNotIn("@pname{", listmd)
+            self.assertIsNone(llms_gen.MARKUP_RE.search(listmd))
 
 
 if __name__ == "__main__":

--- a/docs/test_llms_gen.py
+++ b/docs/test_llms_gen.py
@@ -117,6 +117,56 @@ class RenderInlineTest(unittest.TestCase):
         self.assertIn("Only detail.", out)
 
 
+class MemberAndGroupTest(unittest.TestCase):
+    def _member(self):
+        xml = (
+            '<memberdef kind="function" id="m1">'
+            "<type>bool</type>"
+            "<definition>bool tgen::math::is_prime</definition>"
+            "<argsstring>(uint64_t n)</argsstring>"
+            "<name>is_prime</name>"
+            "<briefdescription><para>Checks if prime.</para></briefdescription>"
+            "<detaileddescription>"
+            '<para><parameterlist kind="param"><parameteritem>'
+            "<parameternamelist><parametername>n</parametername></parameternamelist>"
+            "<parameterdescription><para>Number.</para></parameterdescription>"
+            "</parameteritem></parameterlist>"
+            '<simplesect kind="return"><para>If prime.</para></simplesect></para>'
+            "</detaileddescription>"
+            "</memberdef>"
+        )
+        return el(xml)
+
+    def test_member_signature(self):
+        sig = llms_gen._member_signature(self._member())
+        self.assertIn("is_prime", sig)
+        self.assertIn("uint64_t n", sig)
+        self.assertIn("bool", sig)
+
+    def test_render_member(self):
+        out = llms_gen.render_member(self._member())
+        self.assertIn("#### `is_prime`", out)
+        self.assertIn("```cpp", out)
+        self.assertIn("Checks if prime.", out)
+        self.assertIn("**Returns:** If prime.", out)
+
+    def test_render_compound_members_skips_variables(self):
+        compound = el(
+            '<compounddef kind="struct">'
+            '<sectiondef kind="public-func">'
+            + ET.tostring(self._member(), encoding="unicode")
+            + "</sectiondef>"
+            '<sectiondef kind="public-attrib">'
+            '<memberdef kind="variable" id="v1"><name>field</name>'
+            "<type>int</type></memberdef>"
+            "</sectiondef>"
+            "</compounddef>"
+        )
+        members = llms_gen.render_compound_members(compound)
+        self.assertIn("is_prime", members)
+        self.assertNotIn("field", members)
+
+
 class ParameterAndSimpleSectTest(unittest.TestCase):
     def test_parameterlist_and_return(self):
         xml = (

--- a/docs/test_llms_gen.py
+++ b/docs/test_llms_gen.py
@@ -119,6 +119,73 @@ class RenderInlineTest(unittest.TestCase):
         self.assertIn("Only detail.", out)
 
 
+class VisibilityScopedTagTest(unittest.TestCase):
+    def test_htmlonly_content_dropped(self):
+        xml = (
+            "<para>before<htmlonly><script>junk()</script></htmlonly>after</para>"
+        )
+        out = llms_gen.render_node(el(xml))
+        self.assertIn("before", out)
+        self.assertIn("after", out)
+        self.assertNotIn("junk", out)
+        self.assertNotIn("<script", out)
+
+    def test_latexonly_content_dropped(self):
+        xml = "<para>a<latexonly>\\latex{cmd}</latexonly>b</para>"
+        out = llms_gen.render_node(el(xml))
+        self.assertIn("a", out)
+        self.assertIn("b", out)
+        self.assertNotIn("latex", out)
+
+
+class DashEntityTest(unittest.TestCase):
+    def test_ndash_and_mdash(self):
+        xml = "<para>use <ndash/>flag and <mdash/>x</para>"
+        out = llms_gen.render_node(el(xml))
+        self.assertIn("--flag", out)
+        self.assertIn("---x", out)
+
+
+class SimpleSectBlockTest(unittest.TestCase):
+    def test_simplesect_preserves_code_block(self):
+        xml = (
+            '<simplesect kind="note"><para>see'
+            '<programlisting filename=".cpp"><codeline>'
+            '<highlight class="normal">int x;</highlight>'
+            "</codeline></programlisting></para></simplesect>"
+        )
+        out = llms_gen.render_node(el(xml))
+        self.assertIn("**Note:**", out)
+        self.assertIn("```cpp\nint x;", out)
+
+
+class ErrorHandlingTest(unittest.TestCase):
+    def test_discover_groups_missing_dir_exits(self):
+        with self.assertRaises(SystemExit):
+            llms_gen.discover_groups("/no/such/dir")
+
+    def test_generate_missing_dir_exits(self):
+        with tempfile.TemporaryDirectory() as out:
+            with self.assertRaises(SystemExit):
+                llms_gen.generate("/no/such/dir", out, "https://example.com/")
+
+    def test_load_compounddef_malformed_exits(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "bad.xml")
+            with open(path, "w") as f:
+                f.write("<compounddef><not-closed>")
+            with self.assertRaises(SystemExit):
+                llms_gen._load_compounddef(d, "bad")
+
+    def test_validate_missing_module_exits(self):
+        with tempfile.TemporaryDirectory() as out:
+            with open(os.path.join(out, "llms.txt"), "w") as f:
+                f.write("# tgen\n")
+            incomplete = [m for m in llms_gen.EXPECTED_MODULES if m != "list"]
+            with self.assertRaises(SystemExit):
+                llms_gen._validate(out, incomplete)
+
+
 class MemberAndGroupTest(unittest.TestCase):
     def _member(self):
         xml = (
@@ -241,6 +308,15 @@ class SmokeXmlTest(unittest.TestCase):
             self.assertNotIn("@tt{", listmd)
             self.assertNotIn("@pname{", listmd)
             self.assertIsNone(llms_gen.MARKUP_RE.search(listmd))
+
+            with open(os.path.join(out, "llms", "base.md")) as f:
+                basemd = f.read()
+            for junk in ("<script", "wnext-viz", "addEventListener", "getElementById"):
+                self.assertNotIn(junk, basemd)
+
+            with open(os.path.join(out, "llms", "opts.md")) as f:
+                optsmd = f.read()
+            self.assertIn("--", optsmd)
 
 
 if __name__ == "__main__":

--- a/docs/test_llms_gen.py
+++ b/docs/test_llms_gen.py
@@ -117,5 +117,44 @@ class RenderInlineTest(unittest.TestCase):
         self.assertIn("Only detail.", out)
 
 
+class ParameterAndSimpleSectTest(unittest.TestCase):
+    def test_parameterlist_and_return(self):
+        xml = (
+            "<detaileddescription><para>"
+            '<parameterlist kind="param"><parameteritem>'
+            "<parameternamelist><parametername>size</parametername></parameternamelist>"
+            "<parameterdescription><para>length</para></parameterdescription>"
+            "</parameteritem></parameterlist>"
+            '<simplesect kind="return"><para>a generator</para></simplesect>'
+            "</para></detaileddescription>"
+        )
+        out = llms_gen.render_description(None, el(xml))
+        self.assertIn("**Parameters:**", out)
+        self.assertIn("`size` — length", out)
+        self.assertIn("**Returns:** a generator", out)
+
+    def test_templateparam_label(self):
+        xml = (
+            "<detaileddescription><para>"
+            '<parameterlist kind="templateparam"><parameteritem>'
+            "<parameternamelist><parametername>T</parametername></parameternamelist>"
+            "<parameterdescription><para>the type</para></parameterdescription>"
+            "</parameteritem></parameterlist>"
+            "</para></detaileddescription>"
+        )
+        out = llms_gen.render_description(None, el(xml))
+        self.assertIn("**Template parameters:**", out)
+        self.assertIn("`T` — the type", out)
+
+    def test_simplesect_note(self):
+        xml = (
+            "<detaileddescription><para>"
+            '<simplesect kind="note"><para>be careful</para></simplesect>'
+            "</para></detaileddescription>"
+        )
+        out = llms_gen.render_description(None, el(xml))
+        self.assertIn("**Note:** be careful", out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ DOC_HTML_DIR  := $(DOC_BUILD_DIR)
 DOC_INDEX     := $(abspath $(DOC_HTML_DIR)/index.html)
 DOC_SRC_DIR   := docs
 THEME_DIR     := docs/doxygen-awesome-css
-LLM_BASE_URL  ?= https://rsalesc.github.io/tgen
+LLM_BASE_URL  ?= https://brunomaletta.github.io/tgen
 
 # Extra argv for runnable examples, e.g. make graph ARGS='--seed 1'   (also works with graph-asan, etc.)
 ARGS ?=

--- a/makefile
+++ b/makefile
@@ -6,6 +6,7 @@ DOC_HTML_DIR  := $(DOC_BUILD_DIR)
 DOC_INDEX     := $(abspath $(DOC_HTML_DIR)/index.html)
 DOC_SRC_DIR   := docs
 THEME_DIR     := docs/doxygen-awesome-css
+LLM_BASE_URL  ?= https://rsalesc.github.io/tgen
 
 # Extra argv for runnable examples, e.g. make graph ARGS='--seed 1'   (also works with graph-asan, etc.)
 ARGS ?=
@@ -71,7 +72,7 @@ $(eval $(call EXAMPLE_LINK_RULE,range_queries,range_queries.cpp,$(CXX_GCC)))
 $(eval $(call EXAMPLE_LINK_RULE,unordered_clang,unordered_set.cpp,$(CXX_CLANG)))
 $(eval $(call EXAMPLE_DEBUG_RULE,sample_debug,all.cpp,$(CXX_GCC)))
 
-.PHONY: all doc doc-rebuild clean-doc opendoc lint lint-check test test_clang test_asan \
+.PHONY: all doc llms doc-rebuild clean-doc opendoc lint lint-check test test_clang test_asan \
 	sample sample_debug unordered range_queries unordered_clang graph cloc \
 	help print-% %-asan
 
@@ -139,6 +140,24 @@ doc:
 	# GitHub Pages safety
 	touch $(DOC_HTML_DIR)/.nojekyll
 
+	$(MAKE) llms
+
+# LLM-friendly markdown docs: a second, XML-only Doxygen run + a python converter.
+# Leaves the HTML build untouched. Output: $(DOC_HTML_DIR)/llms.txt and $(DOC_HTML_DIR)/llms/*.md
+llms:
+	mkdir -p $(DOC_HTML_DIR)
+	cd $(DOC_SRC_DIR) && { \
+	printf '%s\n' '@INCLUDE = Doxyfile' 'GENERATE_HTML=NO' 'GENERATE_XML=YES' \
+		'GENERATE_LATEX=NO' 'GENERATE_DOCBOOK=NO' \
+		'OUTPUT_DIRECTORY=build' 'XML_OUTPUT=xml' \
+		'NUM_PROC_THREADS = $(NPROCS)' 'DOT_NUM_THREADS = $(NPROCS)'; \
+	} | doxygen -
+	python3 $(DOC_SRC_DIR)/llms_gen.py \
+		--xml $(DOC_BUILD_DIR)/xml \
+		--out $(DOC_HTML_DIR) \
+		--base-url '$(LLM_BASE_URL)'
+	rm -rf $(DOC_BUILD_DIR)/xml
+
 doc-rebuild:
 	$(MAKE) clean-doc doc
 
@@ -199,7 +218,7 @@ help:
 	@echo " + argv:   make graph ARGS='…'   (sample, graph, graph-asan, …)"
 	@echo " + ASan:   make graph ASAN=1   or   make graph-asan   (same for sample-asan, unordered-asan, …)"
 	@echo "           Binaries: build/examples/rel/… and build/examples/asan/… (see ASAN=1)"
-	@echo "Docs:      make doc | doc-rebuild | opendoc | clean-doc   (doc-rebuild = clean + doc)"
+	@echo "Docs:      make doc | doc-rebuild | opendoc | clean-doc | llms   (doc also builds llms; doc-rebuild = clean + doc)"
 	@echo "Other:     make lint | lint-check | clean | cloc | print-CXXFLAGS_COMMON"
 
 print-%:

--- a/makefile
+++ b/makefile
@@ -158,8 +158,12 @@ llms:
 		--base-url '$(LLM_BASE_URL)'
 	rm -rf $(DOC_BUILD_DIR)/xml
 
+# Two separate sub-makes (not `$(MAKE) clean-doc doc`): `MAKEFLAGS += -j$(NPROCS)`
+# forces the sub-make parallel, so passing both goals at once lets clean-doc's
+# `rm -rf docs/build` race the doc recipe writing into docs/build. The `&&`
+# guarantees the wipe finishes before the build starts.
 doc-rebuild:
-	$(MAKE) clean-doc doc
+	$(MAKE) clean-doc && $(MAKE) doc
 
 clean-doc:
 	rm -rf $(DOC_BUILD_DIR)


### PR DESCRIPTION
## Summary

Adds an LLM-friendly markdown documentation tree generated from the existing Doxygen sources and published to GitHub Pages alongside the untouched HTML. An agent can be handed a single link (`https://brunomaletta.github.io/tgen/llms.txt`), see the module map, and fetch only the leaves it needs.

- New stdlib-only converter `docs/llms_gen.py` walks Doxygen XML and emits an `llms.txt` index + one `llms/<module>.md` per `@defgroup` (overview, worked `cpp` examples, signatures, params/returns). No pip/node deps.
- `make llms` runs a second, XML-only Doxygen pass (HTML build untouched) and the converter, then deletes the temp XML. Folded into `make doc`; the docs CI builds it before the Pages upload.
- `docs/test_llms_gen.py`: 29 `unittest` tests (TDD). Self-validation fails the build on leaked Doxygen markup or missing modules.
- Doxyfile `EXCLUDE_PATTERNS` keeps the Python tooling out of the HTML/XML, so the existing docs stay byte-for-byte unchanged.
- Design + implementation plan under `docs/plans/`.

Base URL defaults to `https://brunomaletta.github.io/tgen` and is overridable: `make llms LLM_BASE_URL=https://example.org/x`.

## Test plan

- [ ] `make doc-rebuild` succeeds; `docs/build/index.html` still present (HTML unchanged), `docs/build/llms.txt` + 12 `docs/build/llms/*.md` generated, temp `docs/build/xml` cleaned up.
- [ ] `cd docs && python3 -m unittest test_llms_gen` passes.
- [ ] After merge: `https://brunomaletta.github.io/tgen/llms.txt` and a module link (e.g. `.../llms/list.md`) resolve and render as raw markdown.
- [ ] Hand `llms.txt` to an agent and confirm it can write a working `tgen` generator.

## Notes

- Two pre-existing source-doc bugs (also present in the current HTML docs) were left out of this PR: `docs/hack.dox`'s example calls `expo_dijkstra_bug(...)` but the symbol is `exponential_dijkstra_bug` (won't compile), and a Codeforces link typo. Happy to fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)