### PR TITLE
docs: fix incorrect Codeforces link (entry/4898 → entry/60442)

### DIFF
--- a/docs/hack.dox
+++ b/docs/hack.dox
@@ -124,7 +124,7 @@ namespace tgen::hack {
  * @return A @tt{@namespace{std}\::pair} with the colliding strings.
  *
  * Reference:
- * - <a href="https://codeforces.com/blog/entry/4898">On the mathematics behind rolling hashes and anti-hash
+ * - <a href="https://codeforces.com/blog/entry/60442">On the mathematics behind rolling hashes and anti-hash
  *   tests</a>: Composition-attack: Multiple hashes
 
  *


### PR DESCRIPTION
Fixes #108 — one of three identical link texts in `docs/hack.dox` pointed to wrong Codeforces entry (4898 instead of 60442).